### PR TITLE
Feature: Add support for RHEL HA 9

### DIFF
--- a/templates/lastnode.template.yaml
+++ b/templates/lastnode.template.yaml
@@ -171,14 +171,16 @@ Resources:
             sudo wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -O /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
             sudo easy_install-3 --script-dir /usr/local/bin /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
           else
-            sudo dnf -y install wget python3 python3-setuptools python3-pip unzip
+            sudo dnf -y install wget python3 python3-setuptools python3-pip unzip resource-agents-cloud
             curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip
             cd /tmp
             unzip /tmp/awscliv2.zip
             sudo /tmp/aws/install
+            sudo ln -s /usr/local/bin/aws /usr/bin/aws
             rm -rf /tmp/aws
             sudo wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -O /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
             sudo pip3 install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
+            sudo pip3 install boto3
           fi
 
           sudo /usr/local/bin/cfn-init -v --stack "${AWS::StackName}" --resource "RHELwithHAInstance" --configsets setup --region "${AWS::Region}"

--- a/templates/node.template.yaml
+++ b/templates/node.template.yaml
@@ -156,14 +156,16 @@ Resources:
             sudo wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -O /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
             sudo easy_install-3 --script-dir /usr/local/bin /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
           else
-            sudo dnf -y install wget python3 python3-setuptools python3-pip unzip
+            sudo dnf -y install wget python3 python3-setuptools python3-pip unzip resource-agents-cloud
             curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip
             cd /tmp
             unzip /tmp/awscliv2.zip
             sudo /tmp/aws/install
+            sudo ln -s /usr/local/bin/aws /usr/bin/aws
             rm -rf /tmp/aws
             sudo wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -O /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
             sudo pip3 install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
+            sudo pip3 install boto3
           fi
 
           sudo /usr/local/bin/cfn-init -v --stack "${AWS::StackName}" --resource "RHELwithHAInstance" --configsets setup --region "${AWS::Region}"


### PR DESCRIPTION
Refactoring, cleanup and testing of RHEL 8 related code performed.
OS detection added to UserData script, differences (packages, config) between RHEL 8 and 9 identified and implemented.
Test deployments with RHEL HA 9.2 (`NodeOS: "RHELHA92HVM"`) and RHEL HA 8.8 (`NodeOS: "RHELHA88HVM"`) performed and compared, same results, working cluster with basic configuration.