### PR TITLE
fix: disable nm-cloud-setup service and timer

### DIFF
--- a/templates/lastnode.template.yaml
+++ b/templates/lastnode.template.yaml
@@ -248,11 +248,17 @@ Resources:
               env:
                 CLUSTERPASSWORD: !Ref ClusterPassword
         service:
-          commands:
-            a_startservice:
-              command: "sudo systemctl start pcsd.service"
-            b_enableservice:
-              command: "sudo systemctl enable pcsd.service"
+          services:
+            systemd:
+              pcsd:
+                enabled: "true"
+                ensureRunning: "true"
+              nm-cloud-setup:
+                enabled: "false"
+                ensureRunning: "false"
+              nm-cloud-setup.timer:
+                enabled: "false"
+                ensureRunning: "false"
         cluster:
           commands:
             execute:

--- a/templates/node.template.yaml
+++ b/templates/node.template.yaml
@@ -234,11 +234,17 @@ Resources:
               env:
                 CLUSTERPASSWORD: !Ref ClusterPassword
         service:
-          commands:
-            a_startservice:
-              command: "sudo systemctl start pcsd.service"
-            b_enableservice:
-              command: "sudo systemctl enable pcsd.service"
+          services:
+            systemd:
+              pcsd:
+                enabled: "true"
+                ensureRunning: "true"
+              nm-cloud-setup:
+                enabled: "false"
+                ensureRunning: "false"
+              nm-cloud-setup.timer:
+                enabled: "false"
+                ensureRunning: "false"
     Properties:
       KeyName: !Ref KeyPairName
       InstanceType: !Ref InstanceType


### PR DESCRIPTION
Following the RHEL HA FAQ / Configuration Guide:

```
If you are using Red Hat 8.6 or later, the following services must be stopped and disabled on both the cluster nodes. This prevents the NetworkManager from removing the overlay IP address from the network interface.

systemctl disable nm-cloud-setup.timer
systemctl stop nm-cloud-setup.timer
systemctl disable nm-cloud-setup
systemctl stop nm-cloud-setup
```

Disabling service and timer added to cfn init metadata, service part refactored to use `services` instead of plain `commands`.