### PR TITLE
Improve security, reduce IAM policy permissions

### DIFF
--- a/templates/lastnode.template.yaml
+++ b/templates/lastnode.template.yaml
@@ -23,9 +23,6 @@ Parameters:
     Description: Password used for the user HACluster in the RHEL HA setup
     Type: String
     NoEcho: true
-  ClusterRole:
-    Description: IAM Role for access to the S3 Buckets
-    Type: String
   FloatingIPAddress:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$
     ConstraintDescription: IP Address must be in the form x.x.x.x
@@ -45,10 +42,6 @@ Resources:
   RHELwithHAInstance:
     Type: AWS::EC2::Instance
     Metadata:
-      AWS::CloudFormation::Authentication:
-        S3AccessCreds:
-          type: S3
-          roleName: !Ref ClusterRole
       AWS::CloudFormation::Init:
         configSets:
           setup:

--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -649,18 +649,6 @@ Resources:
       Description: "RHEL with HA Partner Solution - EC2 Instance IAM Role to allow fencing and ssm agent usage"
       Path: /
       Policies:
-        - PolicyName: root
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - s3:ListBucket
-                  - s3:GetObject
-                  - s3:PutObject
-                Resource:
-                  - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]
-                  - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]  
         - PolicyName: NodeFencing
           PolicyDocument:
             Version: "2012-10-17"
@@ -741,7 +729,6 @@ Resources:
         LaunchTemplateId: !Ref RHELwithHAInstanceLaunchTemplate
         SubnetId: !GetAtt VPCStack.Outputs.PrivateSubnet1AID
         ClusterPassword: !Ref ClusterPassword
-        ClusterRole: !Ref ClusterRole
         WaitHandle: !Ref WaitHandle
 
   ExtraNode1Stack:
@@ -758,7 +745,6 @@ Resources:
         LaunchTemplateId: !Ref RHELwithHAInstanceLaunchTemplate
         SubnetId: !GetAtt VPCStack.Outputs.PrivateSubnet3AID
         ClusterPassword: !Ref ClusterPassword
-        ClusterRole: !Ref ClusterRole
         WaitHandle: !Ref WaitHandle
 
   ExtraNode2Stack:
@@ -775,7 +761,6 @@ Resources:
         LaunchTemplateId: !Ref RHELwithHAInstanceLaunchTemplate
         SubnetId: !GetAtt VPCStack.Outputs.PrivateSubnet4AID
         ClusterPassword: !Ref ClusterPassword
-        ClusterRole: !Ref ClusterRole
         WaitHandle: !Ref WaitHandle
 
   LastNodeStack:
@@ -796,7 +781,6 @@ Resources:
         LaunchTemplateId: !Ref RHELwithHAInstanceLaunchTemplate
         SubnetId: !GetAtt VPCStack.Outputs.PrivateSubnet2AID
         ClusterPassword: !Ref ClusterPassword
-        ClusterRole: !Ref ClusterRole
         FloatingIPAddress: !Ref FloatingIPAddress
         RouteTableId: !Join
           - ','

--- a/templates/node.template.yaml
+++ b/templates/node.template.yaml
@@ -23,19 +23,12 @@ Parameters:
     Description: Password used for the user HACluster in the RHEL HA setup
     Type: String
     NoEcho: true
-  ClusterRole:
-    Description: IAM Role for access to the S3 Buckets
-    Type: String
   WaitHandle:
     Type: String
 Resources:
   RHELwithHAInstance:
     Type: AWS::EC2::Instance
     Metadata:
-      AWS::CloudFormation::Authentication:
-        S3AccessCreds:
-          type: S3
-          roleName: !Ref ClusterRole
       AWS::CloudFormation::Init:
         configSets:
           setup:


### PR DESCRIPTION
This PR has the goal to assign the least possible permissions to the IAM role used by the cluster instances and avoid usage of wildcard permissions.
- Unused S3 permissions from the instance role and related parameters from `node` and `lastnode` template removed.
- Inline policies renamed to make their purpose easier to understand.
- Total amount of ec2 related permissions (`NodeFencing` policy) reduced.
  - During initial cluster setup, usage of `*` necessary to avoid dependency loop (instance ids unknown at this stage). Additional resource introduced to lockdown the IAM policy at the end of the Stack to the specific ec2 instance id's of the RHEL with HA cluster nodes.
- Routing related permissions narrowed down to region and account.