### PR TITLE
Feature: Add node tags, friendly names and customizable clustername

### DIFF
--- a/templates/lastnode.template.yaml
+++ b/templates/lastnode.template.yaml
@@ -43,6 +43,11 @@ Parameters:
     ConstraintDescription: "The cluster name can include numbers, lowercase letters and uppercase letters."
     Description: Internal name of the RHEL with HA cluster, also used as part of the internal node name
     Type: String
+  NodeName:
+    AllowedPattern: "^[0-9a-zA-Z]*$"
+    ConstraintDescription: "The node name can include numbers, lowercase letters and uppercase letters."
+    Description: Internal name of the RHEL with HA node
+    Type: String
 Resources:
   RHELwithHAInstance:
     Type: AWS::EC2::Instance
@@ -126,6 +131,9 @@ Resources:
           fi
 
           sudo dnf -y install https://s3.${AWS::Region}.amazonaws.com/amazon-ssm-${AWS::Region}/latest/linux_amd64/amazon-ssm-agent.rpm
+
+          sudo sh -c 'echo "export NODENAME=${NodeName}.${ClusterName}" > /etc/profile.d/nodename.sh'
+          sudo sh -c "sed -i.bak 's/\\\u@\\\h/\\\u@\$NODENAME (\\\h)/g' /etc/bashrc"
 
           sudo aws configure set default.region "${AWS::Region}"
           sudo /usr/local/bin/cfn-init -v --stack "${AWS::StackName}" --resource "RHELwithHAInstance" --configsets setup --region "${AWS::Region}"

--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -781,6 +781,8 @@ Resources:
         SubnetId: !GetAtt VPCStack.Outputs.PrivateSubnet1AID
         ClusterPassword: !Ref ClusterPassword
         WaitHandle: !Ref WaitHandle
+        ClusterName: !Ref ClusterName
+        NodeName: !Ref Node1Name
 
   ExtraNode1Stack:
     Type: 'AWS::CloudFormation::Stack'
@@ -803,6 +805,8 @@ Resources:
         SubnetId: !GetAtt VPCStack.Outputs.PrivateSubnet3AID
         ClusterPassword: !Ref ClusterPassword
         WaitHandle: !Ref WaitHandle
+        ClusterName: !Ref ClusterName
+        NodeName: !Ref Node2Name
 
   ExtraNode2Stack:
     Type: 'AWS::CloudFormation::Stack'
@@ -825,6 +829,8 @@ Resources:
         SubnetId: !GetAtt VPCStack.Outputs.PrivateSubnet4AID
         ClusterPassword: !Ref ClusterPassword
         WaitHandle: !Ref WaitHandle
+        ClusterName: !Ref ClusterName
+        NodeName: !Ref Node3Name
 
   LastNodeStack:
     Type: 'AWS::CloudFormation::Stack'
@@ -864,6 +870,7 @@ Resources:
             - !If [ ThreeOrFour, !Join [':', [ !GetAtt ExtraNode1Stack.Outputs.PrivateDnsName, !GetAtt ExtraNode1Stack.Outputs.InstanceId ] ], !Ref AWS::NoValue ]
             - !If [ Four, !Join [':', [ !GetAtt ExtraNode2Stack.Outputs.PrivateDnsName, !GetAtt ExtraNode2Stack.Outputs.InstanceId ] ], !Ref AWS::NoValue ]
         ClusterName: !Ref ClusterName
+        NodeName: !If [ ThreeOrFour, !Ref Node3Name, !If [ Four, !Ref Node4Name, !Ref Node2Name ] ]
 
   LockdownClusterRolePolicyReboot:
     Type: AWS::IAM::Policy

--- a/templates/node.template.yaml
+++ b/templates/node.template.yaml
@@ -25,6 +25,16 @@ Parameters:
     NoEcho: true
   WaitHandle:
     Type: String
+  ClusterName:
+    AllowedPattern: "^[0-9a-zA-Z]*$"
+    ConstraintDescription: "The cluster name can include numbers, lowercase letters and uppercase letters."
+    Description: Internal name of the RHEL with HA cluster, also used as part of the internal node name
+    Type: String
+  NodeName:
+    AllowedPattern: "^[0-9a-zA-Z]*$"
+    ConstraintDescription: "The node name can include numbers, lowercase letters and uppercase letters."
+    Description: Internal name of the RHEL with HA node
+    Type: String
 Resources:
   RHELwithHAInstance:
     Type: AWS::EC2::Instance
@@ -89,6 +99,9 @@ Resources:
           fi
 
           sudo dnf -y install https://s3.${AWS::Region}.amazonaws.com/amazon-ssm-${AWS::Region}/latest/linux_amd64/amazon-ssm-agent.rpm
+
+          sudo sh -c 'echo "export NODENAME=${NodeName}.${ClusterName}" > /etc/profile.d/nodename.sh'
+          sudo sh -c "sed -i.bak 's/\\\u@\\\h/\\\u@\$NODENAME (\\\h)/g' /etc/bashrc"
 
           sudo aws configure set default.region "${AWS::Region}"
           sudo /usr/local/bin/cfn-init -v --stack "${AWS::StackName}" --resource "RHELwithHAInstance" --configsets setup --region "${AWS::Region}"


### PR DESCRIPTION
More of a cosmetic PR, the cluster name the individual node names can be customized via cfn parameters.
The cluster name will really be used when creating the RHEL with HA config, the node names are used in the EC2 Instance Tags (`Name`) and are added to the Shell prompt on OS Level. Goal is to make cluster nodes easier to identify in the AWS Console and when working with CLI tools like `pcs`.