### PR TITLE
feat: Allow tags in instance metadata by default

### DIFF
--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -754,6 +754,7 @@ Resources:
         MetadataOptions:
           HttpEndpoint: enabled
           HttpTokens: required
+          InstanceMetadataTags: enabled
         KeyName: !Ref KeyPairName
         InstanceType: !Ref InstanceType
         IamInstanceProfile:


### PR DESCRIPTION
Small PR that allows to retrieve the instance tags via IMDS for new deployed nodes.