### PR TITLE
Fix: QSS3* params default values

### DIFF
--- a/docs/deployment_guide/partner_editable/post_deployment.adoc
+++ b/docs/deployment_guide/partner_editable/post_deployment.adoc
@@ -1,3 +1,3 @@
 // Include any postdeployment steps here, such as steps necessary to test that the deployment was successful. If there are no postdeployment steps, leave this file empty.
 
-== Postdeployment steps
+//== Postdeployment steps

--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -363,7 +363,7 @@ Parameters:
   QSS3BucketName:
     AllowedPattern: "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$"
     ConstraintDescription: "Partner Solution bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
-    Default: aws-quickstart
+    Default: aws-ia-us-east-1
     Description: "S3 bucket name for the Partner Solution assets. Partner Solution bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
     Type: String
   QSS3BucketRegion:
@@ -373,7 +373,7 @@ Parameters:
   QSS3KeyPrefix:
     AllowedPattern: "^[0-9a-zA-Z-/]*$"
     ConstraintDescription: "Partner Solution key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
-    Default: implementing/
+    Default: cfn-ps-red-hat-rhel-with-ha/
     Description: "S3 key prefix for the Partner Solution assets. Partner Solution key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
     Type: String
   NodeOS:

--- a/templates/test.byovpc.yaml
+++ b/templates/test.byovpc.yaml
@@ -136,7 +136,7 @@ Parameters:
   QSS3BucketName:
     AllowedPattern: "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$"
     ConstraintDescription: "Partner Solution bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
-    Default: aws-quickstart
+    Default: aws-ia-us-east-1
     Description: "S3 bucket name for the Partner Solution assets. Partner Solution bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
     Type: String
   QSS3BucketRegion:
@@ -146,7 +146,7 @@ Parameters:
   QSS3KeyPrefix:
     AllowedPattern: "^[0-9a-zA-Z-/]*$"
     ConstraintDescription: "Partner Solution key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
-    Default: implementing/
+    Default: cfn-ps-red-hat-rhel-with-ha/
     Description: "S3 key prefix for the Partner Solution assets. Partner Solution key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
     Type: String
   NodeOS:


### PR DESCRIPTION
Defaults pointing to wrong S3 bucket and causing deployment via https://fwd.aws/WMVVE to fail.